### PR TITLE
Use get() to check g:loaded_airline

### DIFF
--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -133,7 +133,7 @@ endfunction
 " Ensure line number is update every time the status line is updated
 function! s:LoadCursorLineNrUpdates()
     " Only add to statusline if Airline is loaded and it has not been added
-    if g:loaded_airline == 1
+    if get(g:, 'loaded_airline', 0) == 1
         if exists('g:airline_section_z') && g:airline_section_z !~ 'UpdateCursorLineNr'
             let g:airline_section_z .= '%{UpdateCursorLineNr()}'
             " Force color to update now


### PR DESCRIPTION
The plugin throws an error if it's loaded before airline:

```
Error detected while processing function <SNR>23_SetupAirlineColorNum..<SNR>23_EnableAirlineColorNum..<SNR>23_LoadCursorLineNrUpdates:
line    2:
E121: Undefined variable: g:loaded_airline
E15: Invalid expression: g:loaded_airline == 1
```

Using `get(g:, ...` fixes the issue.
