### PR TITLE
Don't sendkeys() \<left> first at cursor pos 1

### DIFF
--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -137,7 +137,11 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    call feedkeys("\<left>\<right>", 'n')
+                    if col('.') == 1
+                        call feedkeys("\<right>\<left>", 'n')
+                    else 
+                        call feedkeys("\<left>\<right>", 'n')
+                    endif
                 endif
 
                 " Save last mode


### PR DESCRIPTION
If you're at the beginning of the line and you
`sendkeys(\<left>\<right>)`, the \left doesn't actually move you, but the
`\right` still will. This breaks visual block insert at the beginning of
the line.

This patch checks if cursor is at the beginning of the line and reverses
the order in such a case.

Signed-off-by: Nicky Sielicki me@nicky.io
