### PR TITLE
Add reversed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ This plugin is enabled by default.
    ```
    let g:airline_colornum_reversed = 1
    ```
-   Example:
    ![Reversed Example](https://i.imgur.com/qum5ocr.png)
 
 ##Troubleshooting

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ This plugin is enabled by default.
    :EnableAirlineColorNum
    ```
 
+*  To enable the reversed mode in your `.vimrc`:
+   ```
+   let g:airline_colornum_reversed = 1
+   ```
+   Example:
+   ![Reversed Example](https://i.imgur.com/qum5ocr.png)
+
 ##Troubleshooting
 If you are not seeing the highlight in certain modes, make sure your cursorline
 is enabled by adding this to your `.vimrc`:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin is enabled by default.
    ```
    let g:airline_colornum_enabled = 0
    ```
-   
+
 *  To disable this plugin temporarily:
    ```
    :DisableAirlineColorNum
@@ -42,7 +42,7 @@ This plugin is enabled by default.
    ```
    :EnableAirlineColorNum
    ```
-   
+
 ##Troubleshooting
 If you are not seeing the highlight in certain modes, make sure your cursorline
 is enabled by adding this to your `.vimrc`:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This plugin is enabled by default.
    ```
    let g:airline_colornum_reversed = 1
    ```
-   ![Reversed Example](https://i.imgur.com/qum5ocr.png)
+   ![Reversed Example](https://i.imgur.com/AER7ig2.png)
 
 ##Troubleshooting
 If you are not seeing the highlight in certain modes, make sure your cursorline

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -181,7 +181,7 @@ function! UpdateCursorLineNr()
                 call <SID>SetCursorLineNrColor()
 
                 " Cause the cursor line num to be redrawn to update color
-                if <SID>ShouldRedrawCursorLineNr()
+                if <SID>ShouldRedrawCursorLineNr() && &filetype != "java"
                     if col('.') == 1
                         call feedkeys("\<right>\<left>", 'n')
                     else

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -109,10 +109,6 @@ function! s:SetCursorLineNrColor()
             endif
             let l:mode_colors_exec = add(l:mode_colors_exec, 'cterm=bold,reverse')
             let l:mode_colors_exec = add(l:mode_colors_exec, 'gui=bold,reverse')
-        else
-            echom "Error setting resolve_index! - Unknown airline_colornum_reversed option: ".
-                    \ g:airline_colornum_reversed
-            return
         endif
         for l:i in range(0, 3, 1)
             if !empty(l:mode_colors[l:i])

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -130,6 +130,7 @@ endfunction
 "   Force a redraw when changing Airline theme
 function! s:ShouldRedrawCursorLineNr()
     if s:airline_mode == 'visual' ||
+       \ s:airline_mode == 'normal' ||
        \ s:last_airline_mode =~ '_modified' ||
        \ s:last_airline_mode == 'toggledoff' ||
        \ g:airline_theme != s:last_airline_theme ||

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -78,23 +78,23 @@ endfunction
 " Get the current LineNr background colors
 " The ariline background is not the same as the LineNr background
 function! s:GetLineNrBgColor()
-	redir => linenr_colors
-		silent highlight LineNr
-	redir END
-	let linenr_bg_colors = []
-	for term in split(linenr_colors)
-		if term =~ 'ctermbg='
-			let linenr_bg_colors = add(linenr_bg_colors, term[len('ctermbg='):])
-		elseif term =~ 'guibg='
-			let linenr_br_colors = add(linenr_bg_colors, term[len('guibg='):])
-		endif
-	endfor
-	" Guarantee the correct order: ['ctermbg', 'guibg']
-	if linenr_bg_colors[0] =~ '#'
-		return reverse(linenr_bg_colors)
-	else
-		return linenr_bg_colors
-	endif
+    redir => linenr_colors
+        silent highlight LineNr
+    redir END
+    let linenr_bg_colors = []
+    for term in split(linenr_colors)
+        if term =~ 'ctermbg='
+            let linenr_bg_colors = add(linenr_bg_colors, term[len('ctermbg='):])
+        elseif term =~ 'guibg='
+            let linenr_bg_colors = add(linenr_bg_colors, term[len('guibg='):])
+        endif
+    endfor
+    " Guarantee the correct order: ['ctermbg', 'guibg']
+    if linenr_bg_colors[0] =~ '#'
+        return reverse(linenr_bg_colors)
+    else
+        return linenr_bg_colors
+    endif
 endfunction
 
 " Set the color of the cursor line number
@@ -103,17 +103,17 @@ function! s:SetCursorLineNrColor()
     let l:mode_colors = <SID>GetAirlineModeColors()
     if !empty(l:mode_colors)
         let l:mode_colors_exec = []
-	let l:linenr_bg_colors = []
-	if g:airline_colornum_reversed == 0
-		let l:resolve_index = [ 'guifg', 'guibg', 'ctermfg', 'ctermbg' ]
-	elseif g:airline_colornum_reversed == 1
-		let l:resolve_index = [ 'guibg', 'guifg', 'ctermbg', 'ctermfg' ]
-		let l:mode_colors_exec = add(l:mode_colors_exec, 'cterm=bold')
-		let l:linenr_bg_colors = <SID>GetLineNrBgColor()
-	else
-		echom "Error setting resolve_index! - airline_colornum_reversed option undefined!"
-		return l:fallback
-	endif
+    let l:linenr_bg_colors = []
+    if g:airline_colornum_reversed == 0
+        let l:resolve_index = [ 'guifg', 'guibg', 'ctermfg', 'ctermbg' ]
+    elseif g:airline_colornum_reversed == 1
+        let l:resolve_index = [ 'guibg', 'guifg', 'ctermbg', 'ctermfg' ]
+        let l:mode_colors_exec = add(l:mode_colors_exec, 'cterm=bold')
+        let l:linenr_bg_colors = <SID>GetLineNrBgColor()
+    else
+        echom "Error setting resolve_index! - airline_colornum_reversed option undefined!"
+        return l:fallback
+    endif
         for l:i in range(0, 3, 1)
             if !empty(l:mode_colors[l:i])
                 let l:mode_colors_exec = add(l:mode_colors_exec,
@@ -121,11 +121,11 @@ function! s:SetCursorLineNrColor()
                     \ l:mode_colors[l:i])
             endif
         endfor
-	if g:airline_colornum_reversed == 1
-		" Override the background set inside the for with the LineNr background
-		let l:mode_colors_exec = add(l:mode_colors_exec, 'ctermbg=' . l:linenr_bg_colors[0])
-		let l:mode_colors_exec = add(l:mode_colors_exec, 'guibg=' . l:linenr_bg_colors[1])
-	endif
+    if g:airline_colornum_reversed == 1
+        " Override the background set inside the for with the LineNr background
+        let l:mode_colors_exec = add(l:mode_colors_exec, 'ctermbg=' . l:linenr_bg_colors[0])
+        let l:mode_colors_exec = add(l:mode_colors_exec, 'guibg=' . l:linenr_bg_colors[1])
+    endif
         exec printf('highlight %s %s',
                 \ 'CursorLineNr',
                 \ join(l:mode_colors_exec, ' '))

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -131,7 +131,7 @@ endfunction
 "   Force a redraw when changing Airline theme
 function! s:ShouldRedrawCursorLineNr()
     if s:airline_mode == 'visual' ||
-       \ s:last_airline_mode == 'visual' ||
+       \ s:airline_mode == 'normal' ||
        \ s:last_airline_mode =~ '_modified' ||
        \ s:last_airline_mode == 'toggledoff' ||
        \ g:airline_theme != s:last_airline_theme ||

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -173,10 +173,10 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    if col('.') == 1
-                        call feedkeys("\<right>\<left>", 'n')
+                    if line('.') == 1
+                        call feedkeys("\<down>\<up>", 'n')
                     else
-                        call feedkeys("\<left>\<right>", 'n')
+                        call feedkeys("\<up>\<down>", 'n')
                     endif
                 endif
 

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -182,10 +182,10 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    if mode() == "v" || mode() == "V" || mode() == "\<C-V>"
-                        call feedkeys("\<up>\<down>", 'n')
+                    if col('.') == 1
+                        call feedkeys("\<right>\<left>", 'n')
                     else
-                        execute "normal! G\<C-O>"
+                        call feedkeys("\<left>\<right>", 'n')
                     endif
                 endif
 

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -182,7 +182,11 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    call feedkeys("\<up>\<down>", 'n')
+                    if mode() == "v" || mode() == "V" || mode() == "\<C-V>"
+                        call feedkeys("\<up>\<down>", 'n')
+                    else
+                        execute "normal! G\<C-O>"
+                    endif
                 endif
 
                 " Save last mode

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -46,6 +46,9 @@ function! s:GetAirlineMode()
         else
             let s:airline_mode = 'normal'
         endif
+        if &modified
+            let s:airline_mode = s:airline_mode . '_modified'
+        endif
     endif
 endfunction
 
@@ -133,11 +136,12 @@ endfunction
 
 " Determines when a redraw of the line number should occur:
 "   ColorLineNr seems to only redraw on cursor moved events for visual mode?
+"   Force a redraw when last mode is a file modified mode
 "   Force a redraw when toggling Airline back on
 "   Force a redraw when changing Airline theme
 function! s:ShouldRedrawCursorLineNr()
     if s:airline_mode == 'visual' ||
-       \ s:last_airline_mode == 'visual' ||
+       \ s:last_airline_mode =~ '_modified' ||
        \ s:last_airline_mode == 'toggledoff' ||
        \ g:airline_theme != s:last_airline_theme ||
        \ s:last_colorscheme != g:colors_name

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -51,7 +51,7 @@ function! s:GetAirlineMode()
         else
             let s:airline_mode = 'normal'
         endif
-        if &modified
+        if &modified && has_key(g:airline#themes#{g:airline_theme}#palette, s:airline_mode . '_modified')
             let s:airline_mode = s:airline_mode . '_modified'
         endif
     endif
@@ -89,9 +89,10 @@ function! s:SetCursorLineNrColor()
     let l:mode_colors = <SID>GetAirlineModeColors()
     if !empty(l:mode_colors)
         let l:mode_colors_exec = []
-        let l:linenr_bg_colors = []
         let l:resolve_index = [ 'guifg', 'guibg', 'ctermfg', 'ctermbg' ]
         if g:airline_colornum_reversed == 1
+            " revert the fg and bg indexes
+            let l:resolve_index = [ 'guibg', 'guifg', 'ctermbg', 'ctermfg' ]
             " Get the current LineNr background color
             let l:linenr_bg_color = synIDattr(hlID("LineNr"), "bg")
             " Alter the background colors to be set
@@ -107,8 +108,8 @@ function! s:SetCursorLineNrColor()
                 let l:mode_colors[0] = 'NONE'
                 let l:mode_colors[2] = 'NONE'
             endif
-            let l:mode_colors_exec = add(l:mode_colors_exec, 'cterm=bold,reverse')
-            let l:mode_colors_exec = add(l:mode_colors_exec, 'gui=bold,reverse')
+            let l:mode_colors_exec = add(l:mode_colors_exec, 'cterm=bold')
+            let l:mode_colors_exec = add(l:mode_colors_exec, 'gui=bold')
         endif
         for l:i in range(0, 3, 1)
             if !empty(l:mode_colors[l:i])
@@ -130,7 +131,7 @@ endfunction
 "   Force a redraw when changing Airline theme
 function! s:ShouldRedrawCursorLineNr()
     if s:airline_mode == 'visual' ||
-       \ s:airline_mode == 'normal' ||
+       \ s:last_airline_mode == 'visual' ||
        \ s:last_airline_mode =~ '_modified' ||
        \ s:last_airline_mode == 'toggledoff' ||
        \ g:airline_theme != s:last_airline_theme ||

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -125,16 +125,10 @@ function! s:SetCursorLineNrColor()
 endfunction
 
 " Determines when a redraw of the line number should occur:
-"   ColorLineNr seems to only redraw on cursor moved events for visual mode?
-"   Force a redraw when last mode is a file modified mode
 "   Force a redraw when toggling Airline back on
 "   Force a redraw when changing Airline theme
 function! s:ShouldRedrawCursorLineNr()
-    if s:airline_mode == 'visual' ||
-       \ s:airline_mode == 'normal' ||
-       \ s:last_airline_mode =~ '_modified' ||
-       \ s:last_airline_mode == 'toggledoff' ||
-       \ g:airline_theme != s:last_airline_theme ||
+    if g:airline_theme != s:last_airline_theme ||
        \ s:last_colorscheme != g:colors_name
         return 1
     endif
@@ -173,10 +167,10 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    if line('.') == 1
-                        call feedkeys("\<down>\<up>", 'n')
+                    if col('.') == 1
+                        call feedkeys("\<right>\<left>", 'n')
                     else
-                        call feedkeys("\<up>\<down>", 'n')
+                        call feedkeys("\<left>\<right>", 'n')
                     endif
                 endif
 

--- a/plugin/airline-colornum.vim
+++ b/plugin/airline-colornum.vim
@@ -182,7 +182,7 @@ function! UpdateCursorLineNr()
 
                 " Cause the cursor line num to be redrawn to update color
                 if <SID>ShouldRedrawCursorLineNr()
-                    call feedkeys("\<left>\<right>", 'n')
+                    call feedkeys("\<up>\<down>", 'n')
                 endif
 
                 " Save last mode
@@ -230,7 +230,7 @@ function! s:AirlineToggledOff()
     let &statusline = s:original_statusline
     " Restore cursor line color and redraw
     call <SID>ResetCursorLineNrColor()
-    call feedkeys("\<right>\<left>", 'n')
+    call feedkeys("\<up>\<down>", 'n')
     " Used to ensure this is re-enabled when Airline is toggled on
     let s:airline_toggled_off = 1
     " Ensures the cursor line number is redrawn correctly


### PR DESCRIPTION
Hi, nice plugin. I added an option to color the cursor line number in a reversed way, i.e., mantain the background the same as `LineNr` and color the number foreground with the `AirLine` mode colors.

The option is disabled by default. To enable it, the user must set the reversed option in `.vimrc`:

```
let g:airline_colornum_reversed = 1
```
